### PR TITLE
Added project.basedir & vaadin.frontend.token.file init params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,13 @@
   </dependencies>
 
  <build>
+   <resources>
+     <resource>
+       <directory>src/main/resources</directory>
+       <filtering>true</filtering>
+     </resource>
+   </resources>
+
     <plugins>
       <plugin>
         <groupId>com.vaadin</groupId>

--- a/src/main/resources/META-INF/resources/frontend/generated-flow-imports.js
+++ b/src/main/resources/META-INF/resources/frontend/generated-flow-imports.js
@@ -1,0 +1,4 @@
+// Copied generated file here because of " ERROR [dev-webpack] (webpack) ERROR in Entry module not found: Error: Can't resolve 'C:\-DEV\Sandbox\vaadin-demo-business-app\target\classes\META-INF\resources\frontend\generated-flow-imports.js' in 'C:\-DEV\Sandbox\vaadin-demo-business-app\frontend'"
+const div = document.createElement('div');
+div.innerHTML = '<custom-style><style include="lumo-color lumo-typography"></style></custom-style>';
+document.head.insertBefore(div.firstElementChild, document.head.firstChild);

--- a/src/main/resources/META-INF/web.xml
+++ b/src/main/resources/META-INF/web.xml
@@ -11,6 +11,14 @@
       <param-name>closeIdleSessions</param-name>
       <param-value>true</param-value>
     </init-param>
+    <init-param>
+      <param-name>project.basedir</param-name>
+      <param-value>${project.basedir}</param-value>
+    </init-param>
+    <init-param>
+      <param-name>vaadin.frontend.token.file</param-name>
+      <param-value>${project.basedir}/target/classes/META-INF/VAADIN/config/flow-build-info.json</param-value>
+    </init-param>
     <async-supported>true</async-supported>
   </servlet>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 quarkus.http.port=8080
 
-quarkus.log.console.format=%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}|%X{service-id}|%X{tenant-id}|%X{traceId}-%X{spanId}|%X{user-id}|%p|%t|%l{32}|%X{message-id}|%m%n
-
-quarkus.log.handler.console."STRUCTURED_LOGGING".format=%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}|%X{service-id}|%X{tenant-id}|%X{traceId}-%X{spanId}|%X{user-id}|%p|%t|%X{logCallerInfo}|%X{message-id}|%m%n
+#quarkus.log.console.format=%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}|%X{service-id}|%X{tenant-id}|%X{traceId}-%X{spanId}|%X{user-id}|%p|%t|%l{32}|%X{message-id}|%m%n
+#quarkus.log.handler.console."STRUCTURED_LOGGING".format=%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}|%X{service-id}|%X{tenant-id}|%X{traceId}-%X{spanId}|%X{user-id}|%p|%t|%X{logCallerInfo}|%X{message-id}|%m%n
+# (Something here is causing a crash in the logger)
 
 quarkus.log.category."ch.inacta.example".level=INFO
 quarkus.log.category."ch.inacta.example".handlers=STRUCTURED_LOGGING


### PR DESCRIPTION
I had something very similar based on the project from moewes. I needed to add some extra init-params
mvn clean package
mvn quarkus:dev

dev mode is starting without backend errors now, but the browser console still looks nasty. Now it does show the webpack:// & webpack-internal:// sources though.
When dev-mode is not working you can't really use Quarkus functions, but have to build something that you can debug on a more conventional app server and that -also- works on Quarkus.